### PR TITLE
Feat/add condition value additional sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,10 +367,15 @@ spec:
     value: ""
 ```
 
-Until now, we talk about the capabilities of the *key* field, but we can take the *value* field from the internal source 
-list, the list will be composed of the workload resource and the resources defined in *additionalSources* field, all in 
-json format. To take the value from a source you have to define a **search structure** 
-'[<list-index>]{{ <GJSON-expression> }}':
+Until now, we have talked about the capabilities of the field `condition.key`, but `condition.value` is really 
+powerful too. If `additionalSources` is filled, the content of these sources is available to craft complex values.
+All you need to do, is to use the pattern `[<list-index>]{{ <GJSON-expression> }}` inside the `condition.value` field
+to use some value coming from a source.
+
+> Hey! Sources is a list composed by `workloadRef` + `additionalSources`. This means position [0] is reserved for 
+> the target workload and higher positions starting from [1] will be filled with additionalSources
+
+Let's see an example:
 
 ```yaml
 apiVersion: rabbit-stalker.docplanner.com/v1alpha1
@@ -384,15 +389,12 @@ spec:
     # string literal example
     key: rabbit@fancy-monk-sample-01
 
-    # This will take the value from a workload annotation named 'node'
+    # This will take the value of an annotation named 'node' coming from workloadRef object
     value: "[0]{{ metadata.annotations.node }}"
 ```
 
-the internal sources list has the workload as its first element (with index 0), the rest of the list will have the 
-elements of *additionalSources* in the same order received.
-
-You can add string literals to the *value* field with the **search structure**, the structure will be replaced by the 
-value found in the source:
+You can craft a value adding some string literals at any side of the pattern used to search. The structure will be 
+replaced by the value found in the source:
 
 ```yaml
 apiVersion: rabbit-stalker.docplanner.com/v1alpha1
@@ -406,13 +408,14 @@ spec:
     # string literal example
     key: rabbit@fancy-monk-sample-01
 
-    # This will take the value from another resource in the source list with an annotation named 'node' with value 1
-    # The '[0]{{ metadata.annotations.node }}' string will be replaced before the comparition so the final value will 
+    # This will take the value of an annotation named 'node' coming from the resource in first position at sources list.
+    # Imagine the value for this annotation is '1'
+    # The '[0]{{ metadata.annotations.node }}' string will be replaced before the comparison, so the final value will 
     # be 'rabbit@fancy-monk-sample-01'
     value: "rabbit@fancy-monk-sample-0[0]{{ metadata.annotations.node }}"
 ```
 
-As final feature you can add multiple **search structures** to build the final string:
+As final feature you can use the patterns as many times as needed to build the final string:
 
 ```yaml
 apiVersion: rabbit-stalker.docplanner.com/v1alpha1

--- a/api/v1alpha1/workloadaction_types.go
+++ b/api/v1alpha1/workloadaction_types.go
@@ -72,7 +72,7 @@ type WorkloadActionSpec struct {
 	// RabbitConnection represents the connection settings to connect with RabbitMQ admin API
 	RabbitConnection RabbitConnectionSpec `json:"rabbitConnection"`
 
-	// Sources TODO
+	// AdditionalSources represent references to Kubernetes resources that whill be available on condition.value
 	AdditionalSources []corev1.ObjectReference `json:"sources,omitempty"`
 
 	// Condition represent a key/value pair found in the JSON of the HTTP response

--- a/api/v1alpha1/workloadaction_types.go
+++ b/api/v1alpha1/workloadaction_types.go
@@ -73,7 +73,7 @@ type WorkloadActionSpec struct {
 	RabbitConnection RabbitConnectionSpec `json:"rabbitConnection"`
 
 	// AdditionalSources represent references to Kubernetes resources that whill be available on condition.value
-	AdditionalSources []corev1.ObjectReference `json:"sources,omitempty"`
+	AdditionalSources []corev1.ObjectReference `json:"additionalSources,omitempty"`
 
 	// Condition represent a key/value pair found in the JSON of the HTTP response
 	Condition ConditionSpec `json:"condition"`

--- a/api/v1alpha1/workloadaction_types.go
+++ b/api/v1alpha1/workloadaction_types.go
@@ -73,7 +73,7 @@ type WorkloadActionSpec struct {
 	RabbitConnection RabbitConnectionSpec `json:"rabbitConnection"`
 
 	// Sources TODO
-	Sources []corev1.ObjectReference `json:"sources,omitempty"`
+	AdditionalSources []corev1.ObjectReference `json:"sources,omitempty"`
 
 	// Condition represent a key/value pair found in the JSON of the HTTP response
 	Condition ConditionSpec `json:"condition"`

--- a/api/v1alpha1/workloadaction_types.go
+++ b/api/v1alpha1/workloadaction_types.go
@@ -72,6 +72,9 @@ type WorkloadActionSpec struct {
 	// RabbitConnection represents the connection settings to connect with RabbitMQ admin API
 	RabbitConnection RabbitConnectionSpec `json:"rabbitConnection"`
 
+	// Sources TODO
+	Sources []corev1.ObjectReference `json:"sources,omitempty"`
+
 	// Condition represent a key/value pair found in the JSON of the HTTP response
 	Condition ConditionSpec `json:"condition"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -125,7 +126,7 @@ func (in *WorkloadAction) DeepCopyInto(out *WorkloadAction) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 }
 
@@ -184,6 +185,11 @@ func (in *WorkloadActionSpec) DeepCopyInto(out *WorkloadActionSpec) {
 	*out = *in
 	out.Synchronization = in.Synchronization
 	out.RabbitConnection = in.RabbitConnection
+	if in.AdditionalSources != nil {
+		in, out := &in.AdditionalSources, &out.AdditionalSources
+		*out = make([]v1.ObjectReference, len(*in))
+		copy(*out, *in)
+	}
 	out.Condition = in.Condition
 	out.WorkloadRef = in.WorkloadRef
 }
@@ -203,7 +209,7 @@ func (in *WorkloadActionStatus) DeepCopyInto(out *WorkloadActionStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]v1.Condition, len(*in))
+		*out = make([]metav1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/config/crd/bases/rabbit-stalker.docplanner.com_workloadactions.yaml
+++ b/config/crd/bases/rabbit-stalker.docplanner.com_workloadactions.yaml
@@ -137,7 +137,8 @@ spec:
                 - vhost
                 type: object
               sources:
-                description: Sources TODO
+                description: AdditionalSources represent references to Kubernetes
+                  resources that whill be available on condition.value
                 items:
                   description: "ObjectReference contains enough information to let
                     you inspect or modify the referred object. --- New uses of this

--- a/config/crd/bases/rabbit-stalker.docplanner.com_workloadactions.yaml
+++ b/config/crd/bases/rabbit-stalker.docplanner.com_workloadactions.yaml
@@ -55,6 +55,71 @@ spec:
                 - restart
                 - delete
                 type: string
+              additionalSources:
+                description: AdditionalSources represent references to Kubernetes
+                  resources that whill be available on condition.value
+                items:
+                  description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               condition:
                 description: Condition represent a key/value pair found in the JSON
                   of the HTTP response
@@ -136,71 +201,6 @@ spec:
                 - url
                 - vhost
                 type: object
-              sources:
-                description: AdditionalSources represent references to Kubernetes
-                  resources that whill be available on condition.value
-                items:
-                  description: "ObjectReference contains enough information to let
-                    you inspect or modify the referred object. --- New uses of this
-                    type are discouraged because of difficulty describing its usage
-                    when embedded in APIs. 1. Ignored fields.  It includes many fields
-                    which are not generally honored.  For instance, ResourceVersion
-                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
-                    usage help.  It is impossible to add specific help for individual
-                    usage.  In most embedded usages, there are particular restrictions
-                    like, \"must refer only to types A and B\" or \"UID not honored\"
-                    or \"name must be restricted\". Those cannot be well described
-                    when embedded. 3. Inconsistent validation.  Because the usages
-                    are different, the validation rules are different by usage, which
-                    makes it hard for users to predict what will happen. 4. The fields
-                    are both imprecise and overly precise.  Kind is not a precise
-                    mapping to a URL. This can produce ambiguity during interpretation
-                    and require a REST mapping.  In most cases, the dependency is
-                    on the group,resource tuple and the version of the actual struct
-                    is irrelevant. 5. We cannot easily change it.  Because this type
-                    is embedded in many locations, updates to this type will affect
-                    numerous schemas.  Don't make new APIs embed an underspecified
-                    API type they do not control. \n Instead of using this type, create
-                    a locally provided and used type that is well-focused on your
-                    reference. For example, ServiceReferences for admission registration:
-                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                    ."
-                  properties:
-                    apiVersion:
-                      description: API version of the referent.
-                      type: string
-                    fieldPath:
-                      description: 'If referring to a piece of an object instead of
-                        an entire object, this string should contain a valid JSON/Go
-                        field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within
-                        a pod, this would take on a value like: "spec.containers{name}"
-                        (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]"
-                        (container with index 2 in this pod). This syntax is chosen
-                        only to have some well-defined way of referencing a part of
-                        an object. TODO: this design is not final and this field is
-                        subject to change in the future.'
-                      type: string
-                    kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                      type: string
-                    resourceVersion:
-                      description: 'Specific resourceVersion to which this reference
-                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                      type: string
-                    uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                      type: string
-                  type: object
-                  x-kubernetes-map-type: atomic
-                type: array
               synchronization:
                 description: SynchronizationSpec defines the behavior of synchronization
                 properties:

--- a/config/crd/bases/rabbit-stalker.docplanner.com_workloadactions.yaml
+++ b/config/crd/bases/rabbit-stalker.docplanner.com_workloadactions.yaml
@@ -136,6 +136,70 @@ spec:
                 - url
                 - vhost
                 type: object
+              sources:
+                description: Sources TODO
+                items:
+                  description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               synchronization:
                 description: SynchronizationSpec defines the behavior of synchronization
                 properties:

--- a/config/samples/rabbit-stalker_v1alpha1_workloadaction.yaml
+++ b/config/samples/rabbit-stalker_v1alpha1_workloadaction.yaml
@@ -30,12 +30,25 @@ spec:
           name: testing-secret
           key: RABBITMQ_PASSWORD
 
+  # Additional sources to get information from.
+  # This sources can be used on condition.value
+  sources:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: testing-workload
+      namespace: default
+
   # Condition under the action is executed.
   # The 'key' field admits dot notation, and it's covered by gjson
   # Ref: https://github.com/tidwall/gjson
   condition:
-    key: "test"
-    value: "something"
+    key: |-
+      consumer_details.#(channel_details.node==rabbit@fancy-monk-sample-01).channel_details.node
+
+    # Additional sources can be used here to craft complex values using the following pattern:
+    # [index]{{ gjson }}
+    value: |-
+      [0]{{ metadata.annotations.node }}
 
   # Action to do with the workload when the condition is met
   action: "restart"

--- a/config/samples/rabbit-stalker_v1alpha1_workloadaction.yaml
+++ b/config/samples/rabbit-stalker_v1alpha1_workloadaction.yaml
@@ -18,7 +18,7 @@ spec:
     vhost: "shared"
     queue: "your-queue-here"
 
-    # Credentials are optional.
+    # (Optional) Credentials to authenticate against endpoint.
     # If set, both are required
     credentials:
       username:
@@ -30,7 +30,7 @@ spec:
           name: testing-secret
           key: RABBITMQ_PASSWORD
 
-  # Additional sources to get information from.
+  # (Optional) Additional sources to get information from.
   # This sources can be used on condition.value
   additionalSources:
     - apiVersion: apps/v1
@@ -39,9 +39,9 @@ spec:
       namespace: default
 
   # Condition under the action is executed.
-  # The 'key' field admits dot notation, and it's covered by gjson
-  # Ref: https://github.com/tidwall/gjson
   condition:
+    # The 'key' field admits dot notation, and it's covered by gjson
+    # Ref: https://github.com/tidwall/gjson
     key: |-
       consumer_details.#(channel_details.node==rabbit@fancy-monk-sample-01).channel_details.node
 

--- a/config/samples/rabbit-stalker_v1alpha1_workloadaction.yaml
+++ b/config/samples/rabbit-stalker_v1alpha1_workloadaction.yaml
@@ -32,7 +32,7 @@ spec:
 
   # Additional sources to get information from.
   # This sources can be used on condition.value
-  sources:
+  additionalSources:
     - apiVersion: apps/v1
       kind: Deployment
       name: testing-workload

--- a/controllers/workloadaction_controller.go
+++ b/controllers/workloadaction_controller.go
@@ -114,8 +114,9 @@ func (r *WorkloadActionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	defer func() {
 		err = r.Status().Update(ctx, workloadActionManifest)
 		if err != nil {
-			LogInfof(ctx, workloadActionConditionUpdateError, req.Name)
+			LogInfof(ctx, workloadActionConditionUpdateError, err)
 		}
+		err = nil
 	}()
 
 	// 6. Schedule periodical request
@@ -125,6 +126,7 @@ func (r *WorkloadActionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return result, err
 	}
 	result = ctrl.Result{
+		Requeue:      true,
 		RequeueAfter: RequeueTime,
 	}
 

--- a/controllers/workloadaction_status.go
+++ b/controllers/workloadaction_status.go
@@ -36,6 +36,10 @@ const (
 	ConditionReasonInvalidAction        = "InvalidAction"
 	ConditionReasonInvalidActionMessage = "Action is invalid"
 
+	// Condition value parsing failed
+	ConditionReasonConditionValueParsingFailed        = "ConditionValueParsingFailed"
+	ConditionReasonConditionValueParsingFailedMessage = "Condition value parsing process failed"
+
 	// Action execution failed
 	ConditionReasonActionExecutionFailed        = "ActionExecutionFailed"
 	ConditionReasonActionExecutionFailedMessage = "Action failed during execution"

--- a/controllers/workloadaction_sync.go
+++ b/controllers/workloadaction_sync.go
@@ -123,12 +123,12 @@ func (r *WorkloadActionReconciler) GetWorkloadResource(ctx context.Context, work
 }
 
 // addSources return a list with the content of the extra sources
-func (r *WorkloadActionReconciler) addSources(ctx context.Context, workloadActionManifest *rabbitstalkerv1alpha1.WorkloadAction, resources *[]string) (err error) {
+func (r *WorkloadActionReconciler) addAdditionalSources(ctx context.Context, workloadActionManifest *rabbitstalkerv1alpha1.WorkloadAction, resources *[]string) (err error) {
 
 	// Fill the sources content, one by one
 	sourceObject := &unstructured.Unstructured{}
 
-	for _, sourceReference := range workloadActionManifest.Spec.Sources {
+	for _, sourceReference := range workloadActionManifest.Spec.AdditionalSources {
 		sourceObject.SetGroupVersionKind(sourceReference.GroupVersionKind())
 
 		err = r.Get(ctx, client.ObjectKey{
@@ -186,7 +186,7 @@ func (r *WorkloadActionReconciler) GetSourcesList(ctx context.Context, workloadM
 	}
 
 	// Fill the resources list with the sources
-	err = r.addSources(ctx, workloadManifest, &resources)
+	err = r.addAdditionalSources(ctx, workloadManifest, &resources)
 	if err != nil {
 		//r.UpdatePatchCondition(patchManifest, r.NewPatchCondition(ConditionTypeResourcePatched,
 		//	metav1.ConditionFalse,


### PR DESCRIPTION
**Feature:**
  - **Changes:**
    - Add the capability in **spec.condition.value** field of making a search information in a list of resources with GJSON to attach the value of that information to the final value of the field.
      - Add the **spec.additionalSources** field in resource's manifest that represent a list of of kubernetes object references. This list will be added to a *source list* used to search the information.
      - Add the concept of *search structure*: this is the characters structure that will be parsed in the **spec.condition.value** field to search the information in the *source list*. This structure will be replaced in the final value of **spec.condition.value** by the information value found in the *source list*.
      - Update the README with the usage of the feature.
  - **Usage:**
    - In **spec.condition.value** field add one or more *search structures* between the string literals to search information in the *source list*.
      - The *source list* is made up of the workload resource (index 0) and the list obtained from the **spec.additionalSources** field.
      - The *search structure* format: `[<list-index>]{{ <GJSON-expression> }}`.

**Bug Fix:**
  - The function ***SetWorkloadRestartAnnotation*** make that the sync process crash because in some cases the variable **templateAnnotations** was not initializing after the step of modify template annotations (3), so its value was nil, causing dereference of a null pointer.
    - Solution: Initialize the variable **templateAnnotations** to an empty map structure.