### PR TITLE
feat: Add cross-namespace credentials & make vhost optional on regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,23 +58,30 @@ spec:
   # Configuration parameters to be able to connect with RabbitMQ
   rabbitConnection:
     url: "https://your-server.rmq.cloudamqp.com"
-    vhost: "shared"
     queue: "your-queue-here"
     useRegex: true
 
-    # Setting credentials is optional.
-    # ATTENTION: If set, BOT are required
+    # (Optional) Vhost can be set (or not) when searching queues using regex patterns,
+    # (Mandatory) Vhost is required for searches based on exact queue names.
+    vhost: "shared"
+
+    # (Optional) Credentials to authenticate against endpoint.
+    # If set, both are required
     credentials:
       username:
         secretRef:
           name: testing-secret
           key: RABBITMQ_USERNAME
+
+          # (Optional) Getting credentials from other namespace is possible too
+          # When namespace is not defined, the same where this WorkloadAction CR is running will be used
+          namespace: default
       password:
         secretRef:
           name: testing-secret
           key: RABBITMQ_PASSWORD
 
-  # Additional sources to get information from.
+  # (Optional) Additional sources to get information from.
   # This sources can be used on condition.value
   additionalSources:
     - apiVersion: apps/v1
@@ -83,10 +90,13 @@ spec:
       namespace: default
 
   # This is the condition that will trigger the execution of the action.
-  # The 'key' field admits dot notation, and it's covered by gjson
-  # Ref: https://github.com/tidwall/gjson
   condition:
+    # The 'key' field admits dot notation, and it's covered by gjson
+    # Ref: https://github.com/tidwall/gjson
     key: "test"
+
+    # Additional sources from 'additionalSources' field can be used here to craft complex values using the pattern:
+    # [index]{{ gjson }}
     value: "something"
 
   # Action to do with the workload when the condition is met

--- a/api/v1alpha1/workloadaction_types.go
+++ b/api/v1alpha1/workloadaction_types.go
@@ -23,11 +23,14 @@ import (
 
 // SecretKeyReferenceSpec represents a reference to a Secret resource in the same namespace
 type SecretKeyReferenceSpec struct {
+	// Namespace of the Secret.
+	Namespace string `json:"namespace,omitempty"`
+
 	// Name of the Secret.
 	Name string `json:"name"`
 
-	// Key in the Secret, when not specified an implementation-specific default key is used.
-	Key string `json:"key,omitempty"`
+	// Key in the Secret.
+	Key string `json:"key"`
 }
 
 // SynchronizationSpec defines the spec of the synchronization section of a WorkloadAction
@@ -49,7 +52,7 @@ type RabbitConnectionCredentialsSpec struct {
 // RabbitConnectionSpec represents the connection settings to connect with RabbitMQ admin API
 type RabbitConnectionSpec struct {
 	Url         string                          `json:"url"`
-	Vhost       string                          `json:"vhost"`
+	Vhost       string                          `json:"vhost,omitempty"`
 	Queue       string                          `json:"queue"`
 	UseRegex    bool                            `json:"useRegex,omitempty"`
 	Credentials RabbitConnectionCredentialsSpec `json:"credentials,omitempty"`

--- a/config/crd/bases/rabbit-stalker.docplanner.com_workloadactions.yaml
+++ b/config/crd/bases/rabbit-stalker.docplanner.com_workloadactions.yaml
@@ -153,13 +153,16 @@ spec:
                               to a Secret resource in the same namespace
                             properties:
                               key:
-                                description: Key in the Secret, when not specified
-                                  an implementation-specific default key is used.
+                                description: Key in the Secret.
                                 type: string
                               name:
                                 description: Name of the Secret.
                                 type: string
+                              namespace:
+                                description: Namespace of the Secret.
+                                type: string
                             required:
+                            - key
                             - name
                             type: object
                         required:
@@ -174,13 +177,16 @@ spec:
                               to a Secret resource in the same namespace
                             properties:
                               key:
-                                description: Key in the Secret, when not specified
-                                  an implementation-specific default key is used.
+                                description: Key in the Secret.
                                 type: string
                               name:
                                 description: Name of the Secret.
                                 type: string
+                              namespace:
+                                description: Namespace of the Secret.
+                                type: string
                             required:
+                            - key
                             - name
                             type: object
                         required:
@@ -201,7 +207,6 @@ spec:
                 required:
                 - queue
                 - url
-                - vhost
                 type: object
               synchronization:
                 description: SynchronizationSpec defines the behavior of synchronization

--- a/config/samples/rabbit-stalker_v1alpha1_workloadaction.yaml
+++ b/config/samples/rabbit-stalker_v1alpha1_workloadaction.yaml
@@ -15,9 +15,12 @@ spec:
   # Configuration
   rabbitConnection:
     url: "https://your-server.rmq.cloudamqp.com"
-    vhost: "shared"
     queue: "your-queue-here"
     useRegex: true
+
+    # (Optional) Vhost can be set (or not) when searching queues using regex patterns,
+    # (Mandatory) Vhost is required for searches based on exact queue names.
+    vhost: "shared"
 
     # (Optional) Credentials to authenticate against endpoint.
     # If set, both are required
@@ -26,6 +29,10 @@ spec:
         secretRef:
           name: testing-secret
           key: RABBITMQ_USERNAME
+
+          # (Optional) Getting credentials from other namespace is possible too
+          # When namespace is not defined, the same where this WorkloadAction CR is running will be used
+          namespace: default
       password:
         secretRef:
           name: testing-secret
@@ -46,7 +53,7 @@ spec:
     key: |-
       consumer_details.#(channel_details.node==rabbit@fancy-monk-sample-01).channel_details.node
 
-    # Additional sources can be used here to craft complex values using the following pattern:
+    # Additional sources from 'additionalSources' field can be used here to craft complex values using the pattern:
     # [index]{{ gjson }}
     value: |-
       [0]{{ metadata.annotations.node }}

--- a/controllers/workloadaction_controller.go
+++ b/controllers/workloadaction_controller.go
@@ -19,7 +19,9 @@ package controllers
 import (
 	"context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -126,7 +128,7 @@ func (r *WorkloadActionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return result, err
 	}
 	result = ctrl.Result{
-		Requeue:      true,
+		//Requeue:      true,
 		RequeueAfter: RequeueTime,
 	}
 
@@ -153,6 +155,6 @@ func (r *WorkloadActionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkloadActionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&rabbitstalkerv1alpha1.WorkloadAction{}).
+		For(&rabbitstalkerv1alpha1.WorkloadAction{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/controllers/workloadaction_status.go
+++ b/controllers/workloadaction_status.go
@@ -11,13 +11,17 @@ const (
 	// ConditionTypeWorkloadActionReady indicates that the WorkloadAction is ready to act or not
 	ConditionTypeWorkloadActionReady = "WorkloadActionReady"
 
+	// Workload not found
+	ConditionReasonWorkloadNotFound        = "WorkloadNotFound"
+	ConditionReasonWorkloadNotFoundMessage = "Workload resource was not found"
+
 	// Credentials not found
 	ConditionReasonCredentialsNotFound        = "CredentialsNotFound"
 	ConditionReasonCredentialsNotFoundMessage = "Credentials secret or key not found"
 
-	// Credentials not valid
-	//ConditionReasonCredentialsNotValid        = "CredentialsNotValid"
-	//ConditionReasonCredentialsNotValidMessage = "Credentials does not allow to authenticate"
+	// Required field not found
+	ConditionReasonRequiredFieldNotFound        = "RequiredFieldNotFound"
+	ConditionReasonRequiredFieldNotFoundMessage = "Required field not found. Is vhost set on literal queue name?"
 
 	// HTTPRequest failed
 	ConditionReasonUrlParsingFailed        = "UrlParsingFailed"
@@ -27,21 +31,21 @@ const (
 	ConditionReasonHttpResponseNotSuccessful        = "HttpRequestNotSuccessful"
 	ConditionReasonHttpResponseNotSuccessfulMessage = "Http request returned status code: %d"
 
-	// HTTPResponse not valid
-	ConditionReasonHttpResponseNotValid        = "HttpResponseNotValid"
-	ConditionReasonHttpResponseNotValidMessage = "Response can not be parsed"
-
-	// Workload not found
-	ConditionReasonWorkloadNotFound        = "WorkloadNotFound"
-	ConditionReasonWorkloadNotFoundMessage = "Workload resource was not found"
-
-	// Action not valid
-	ConditionReasonInvalidAction        = "InvalidAction"
-	ConditionReasonInvalidActionMessage = "Action is invalid"
+	// Queue not found
+	ConditionReasonQueueNotFound        = "QueueNotFound"
+	ConditionReasonQueueNotFoundMessage = "No queues were found with defined name"
 
 	// Condition value parsing failed
 	ConditionReasonConditionValueParsingFailed        = "ConditionValueParsingFailed"
 	ConditionReasonConditionValueParsingFailedMessage = "Condition value parsing process failed"
+
+	// HTTPResponse not valid
+	ConditionReasonHttpResponseNotValid        = "HttpResponseNotValid"
+	ConditionReasonHttpResponseNotValidMessage = "Response can not be parsed"
+
+	// Action not valid
+	ConditionReasonInvalidAction        = "InvalidAction"
+	ConditionReasonInvalidActionMessage = "Action is invalid"
 
 	// Action execution failed
 	ConditionReasonActionExecutionFailed        = "ActionExecutionFailed"

--- a/controllers/workloadaction_sync.go
+++ b/controllers/workloadaction_sync.go
@@ -1,606 +1,645 @@
 package controllers
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "github.com/pkg/errors"
-    "io"
-    "k8s.io/apimachinery/pkg/types"
-    "net/http"
-    "net/url"
-    "reflect"
-    "regexp"
-    "strconv"
-    "strings"
-    "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"io"
+	"k8s.io/apimachinery/pkg/types"
+	"log"
+	"net/http"
+	"net/url"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
 
-    rabbitstalkerv1alpha1 "docplanner.com/rabbit-stalker/api/v1alpha1"
-    corev1 "k8s.io/api/core/v1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-    "sigs.k8s.io/controller-runtime/pkg/client"
+	rabbitstalkerv1alpha1 "docplanner.com/rabbit-stalker/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-    "github.com/tidwall/gjson"
+	"github.com/tidwall/gjson"
 )
 
 const (
-    // RabbitAdminApiQueuesEndpoint TODO
-    // The endpoint structure looks like this: /api/queues/vhost
-    RabbitAdminApiQueuesEndpoint = "/api/queues/%s"
+	// RabbitAdminApiQueuesEndpoint TODO
+	RabbitAdminApiQueuesEndpoint = "/api/queues"
 
-    // RabbitAdminApiQueueEndpoint TODO
-    // The endpoint structure looks like this: /api/queues/vhost/name
-    //RabbitAdminApiQueueEndpoint = "/api/queues/%s/%s"
+	// Parameters related to RabbitMQ Admin API paginated endpoints
+	StartingPageDefaultValue       = 1
+	PageSizeDefaultValue           = 5
+	UseRegexDefaultValue           = true
+	HttpSchemeDefaultValue         = "https"
+	HttpHeaderAcceptDefaultValue   = "application/json"
+	HttpRequestTimeoutDefaultValue = 5 * time.Second
 
-    // Parameters related to RabbitMQ Admin API paginated endpoints
-    StartingPageDefaultValue = 1
-    PageSizeDefaultValue     = 5
-    UseRegexDefaultValue     = true
+	// TODO
+	AnnotationRestartedAt = "rabbit-stalker.docplanner.com/restartedAt"
 
-    // TODO
-    HttpHeaderAccept   = "application/json"
-    HttpRequestTimeout = 5 * time.Second
+	// parseSyncTimeError error message for invalid value on 'synchronization' parameter
+	parseSyncTimeError = "Can not parse the synchronization time from workloadAction: %s"
 
-    // TODO
-    AnnotationRestartedAt = "rabbit-stalker.docplanner.com/restartedAt"
+	WorkloadRestartNotSupportedErrorMessage   = "restarting is not supported"
+	PausedWorkloadRestartErrorMessage         = "can't restart paused deployment (run rollout resume first)"
+	WorkloadActionAnnotationPatchErrorMessage = "impossible to patch the annotations for the workload template: %s"
+	UnsuccessfulRequestErrorMessage           = "unsuccessful request: %d"
+	InvalidJsonErrorMessage                   = "invalid json from the HTTP response"
+	InvalidActionErrorMessage                 = "invalid action. supported: restart, delete"
+	DeleteActionNotImplementedErrorMessage    = "deletion action is not implemented yet"
+	VhostNotDefinedErrorMessage               = "queues with literal names require vhost field defined"
+	QueuesNotFoundErrorMessage                = "no queues were found with defined name"
 
-    // parseSyncTimeError error message for invalid value on 'synchronization' parameter
-    parseSyncTimeError = "Can not parse the synchronization time from workloadAction: %s"
+	// TODO
+	ResourceKindDeployment  = "Deployment"
+	ResourceKindStatefulSet = "StatefulSet"
+	ResourceKindDaemonSet   = "DaemonSet"
 
-    WorkloadRestartNotSupportedErrorMessage   = "restarting is not supported"
-    PausedWorkloadRestartErrorMessage         = "can't restart paused deployment (run rollout resume first)"
-    WorkloadActionAnnotationPatchErrorMessage = "impossible to patch the annotations for the workload template: %s"
-    UnauthorizedRequestErrorMessage           = "unauthorized request against the connection. Set the credentials for this server"
-    UnsuccessfulRequestErrorMessage           = "unsuccessful request: %d"
-    InvalidJsonErrorMessage                   = "invalid json from the HTTP response"
-    InvalidActionErrorMessage                 = "invalid action. supported: restart, delete"
-    DeleteActionNotImplementedErrorMessage    = "deletion action is not implemented yet"
-
-    // TODO
-    ResourceKindDeployment  = "Deployment"
-    ResourceKindStatefulSet = "StatefulSet"
-    ResourceKindDaemonSet   = "DaemonSet"
-
-    // TODO
-    ActionDelete  = "delete"
-    ActionRestart = "restart"
+	// TODO
+	ActionDelete  = "delete"
+	ActionRestart = "restart"
 )
 
 // HttpRequestAuth represents authentication params provided to a request
 // TODO Move wherever it's better than here
 type HttpRequestAuth struct {
-    Username string
-    Password string
-    Token    string
+	Username string
+	Password string
+	Token    string
 }
 
 // RabbitPaginatedResponse represents a response from an endpoint with pagination params
 // TODO Move wherever it's better than here
 type RabbitPaginatedResponse struct {
-    FilteredCount int           `json:"filtered_count"`
-    ItemCount     int           `json:"item_count"`
-    Items         []interface{} `json:"items"`
-    Page          int           `json:"page"`
-    PageCount     int           `json:"page_count"`
-    PageSize      int           `json:"page_size"`
-    TotalCount    int           `json:"total_count"`
+	FilteredCount int           `json:"filtered_count"`
+	ItemCount     int           `json:"item_count"`
+	Items         []interface{} `json:"items"`
+	Page          int           `json:"page"`
+	PageCount     int           `json:"page_count"`
+	PageSize      int           `json:"page_size"`
+	TotalCount    int           `json:"total_count"`
 }
 
 // GetSynchronizationTime return the spec.synchronization.time as duration, or default time on failures
 func (r *WorkloadActionReconciler) GetSynchronizationTime(workloadActionManifest *rabbitstalkerv1alpha1.WorkloadAction) (synchronizationTime time.Duration, err error) {
-    synchronizationTime, err = time.ParseDuration(workloadActionManifest.Spec.Synchronization.Time)
-    if err != nil {
-        err = NewErrorf(parseSyncTimeError, workloadActionManifest.Name)
-        return synchronizationTime, err
-    }
+	synchronizationTime, err = time.ParseDuration(workloadActionManifest.Spec.Synchronization.Time)
+	if err != nil {
+		err = NewErrorf(parseSyncTimeError, workloadActionManifest.Name)
+		return synchronizationTime, err
+	}
 
-    return synchronizationTime, err
+	return synchronizationTime, err
 }
 
 // GetSecretResource call Kubernetes API to return an arbitrary Secret object
 func (r *WorkloadActionReconciler) GetSecretResource(ctx context.Context, namespace string, name string) (secret *corev1.Secret, err error) {
 
-    secretResource := corev1.Secret{}
+	secretResource := corev1.Secret{}
 
-    err = r.Get(ctx, client.ObjectKey{
-        Namespace: namespace,
-        Name:      name,
-    }, &secretResource)
+	err = r.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, &secretResource)
 
-    secret = &secretResource
-    return secret, err
+	secret = &secretResource
+	return secret, err
 }
 
 // GetCredentialsResources call Kubernetes API to return the Secret objects for the HTTP request authentication
 func (r *WorkloadActionReconciler) GetCredentialsResources(ctx context.Context, workloadActionManifest *rabbitstalkerv1alpha1.WorkloadAction) (resources []*corev1.Secret, err error) {
 
-    usernameSecret := &corev1.Secret{}
-    passwordSecret := &corev1.Secret{}
+	usernameSecret := &corev1.Secret{}
+	passwordSecret := &corev1.Secret{}
 
-    secretNamespace := workloadActionManifest.Namespace
+	// Get the Secret with the username field inside
+	secretNamespace := workloadActionManifest.Namespace
+	if !reflect.ValueOf(workloadActionManifest.Spec.RabbitConnection.Credentials.Username.SecretRef.Namespace).IsZero() {
+		secretNamespace = workloadActionManifest.Spec.RabbitConnection.Credentials.Username.SecretRef.Namespace
+	}
 
-    // Get the Secret with the username field inside
-    secretName := workloadActionManifest.Spec.RabbitConnection.Credentials.Username.SecretRef.Name
-    usernameSecret, usernameErr := r.GetSecretResource(ctx, secretNamespace, secretName)
+	secretName := workloadActionManifest.Spec.RabbitConnection.Credentials.Username.SecretRef.Name
+	usernameSecret, usernameErr := r.GetSecretResource(ctx, secretNamespace, secretName)
 
-    // Get the Secret with the password field inside
-    secretName = workloadActionManifest.Spec.RabbitConnection.Credentials.Password.SecretRef.Name
-    passwordSecret, passwordErr := r.GetSecretResource(ctx, secretNamespace, secretName)
-    if usernameErr != nil || passwordErr != nil {
-        return resources, err
-    }
-    resources = append(resources, usernameSecret)
-    resources = append(resources, passwordSecret)
+	// Get the Secret with the password field inside
+	secretNamespace = workloadActionManifest.Namespace
+	if !reflect.ValueOf(workloadActionManifest.Spec.RabbitConnection.Credentials.Password.SecretRef.Namespace).IsZero() {
+		secretNamespace = workloadActionManifest.Spec.RabbitConnection.Credentials.Password.SecretRef.Namespace
+	}
 
-    return resources, err
+	secretName = workloadActionManifest.Spec.RabbitConnection.Credentials.Password.SecretRef.Name
+	passwordSecret, passwordErr := r.GetSecretResource(ctx, secretNamespace, secretName)
+	if usernameErr != nil || passwordErr != nil {
+		return resources, err
+	}
+	resources = append(resources, usernameSecret)
+	resources = append(resources, passwordSecret)
+
+	return resources, err
 }
 
 // GetWorkloadResource call Kubernetes API to return the WorkloadResource object
 func (r *WorkloadActionReconciler) GetWorkloadResource(ctx context.Context, workloadActionManifest *rabbitstalkerv1alpha1.WorkloadAction) (resource *unstructured.Unstructured, err error) {
 
-    // Get the target manifest
-    target := unstructured.Unstructured{}
-    target.SetGroupVersionKind(workloadActionManifest.Spec.WorkloadRef.GroupVersionKind())
+	// Get the target manifest
+	target := unstructured.Unstructured{}
+	target.SetGroupVersionKind(workloadActionManifest.Spec.WorkloadRef.GroupVersionKind())
 
-    err = r.Get(ctx, client.ObjectKey{
-        Namespace: workloadActionManifest.Spec.WorkloadRef.Namespace,
-        Name:      workloadActionManifest.Spec.WorkloadRef.Name,
-    }, &target)
+	err = r.Get(ctx, client.ObjectKey{
+		Namespace: workloadActionManifest.Spec.WorkloadRef.Namespace,
+		Name:      workloadActionManifest.Spec.WorkloadRef.Name,
+	}, &target)
 
-    resource = &target
-    return resource, err
+	resource = &target
+	return resource, err
 }
 
 // addWorkloadResource add WorkloadRef referenced resource to the sources list
 func (r *WorkloadActionReconciler) addWorkloadResource(ctx context.Context, workloadActionManifest *rabbitstalkerv1alpha1.WorkloadAction, resources *[]string) (err error) {
 
-    // Get the target manifest
-    target, err := r.GetWorkloadResource(ctx, workloadActionManifest)
-    if err != nil {
-        return err
-    }
+	// Get the target manifest
+	target, err := r.GetWorkloadResource(ctx, workloadActionManifest)
+	if err != nil {
+		return err
+	}
 
-    targetObjectJson, err := json.Marshal(target.Object)
-    if err != nil {
-        return err
-    }
+	targetObjectJson, err := json.Marshal(target.Object)
+	if err != nil {
+		return err
+	}
 
-    *resources = append(*resources, string(targetObjectJson))
-    return err
+	*resources = append(*resources, string(targetObjectJson))
+	return err
 }
 
 // addAdditionalSources add additionalSources objects into the sources list
 func (r *WorkloadActionReconciler) addAdditionalSources(ctx context.Context, workloadActionManifest *rabbitstalkerv1alpha1.WorkloadAction, resources *[]string) (err error) {
 
-    // Fill the sources content, one by one
-    sourceObject := &unstructured.Unstructured{}
+	// Fill the sources content, one by one
+	sourceObject := &unstructured.Unstructured{}
 
-    for _, sourceReference := range workloadActionManifest.Spec.AdditionalSources {
-        sourceObject.SetGroupVersionKind(sourceReference.GroupVersionKind())
+	for _, sourceReference := range workloadActionManifest.Spec.AdditionalSources {
+		sourceObject.SetGroupVersionKind(sourceReference.GroupVersionKind())
 
-        err = r.Get(ctx, client.ObjectKey{
-            Namespace: sourceReference.Namespace,
-            Name:      sourceReference.Name,
-        }, sourceObject)
+		err = r.Get(ctx, client.ObjectKey{
+			Namespace: sourceReference.Namespace,
+			Name:      sourceReference.Name,
+		}, sourceObject)
 
-        if err != nil {
-            return err
-        }
+		if err != nil {
+			return err
+		}
 
-        sourceObjectJson, err := json.Marshal(sourceObject.Object)
-        if err != nil {
-            return err
-        }
+		sourceObjectJson, err := json.Marshal(sourceObject.Object)
+		if err != nil {
+			return err
+		}
 
-        *resources = append(*resources, string(sourceObjectJson))
-    }
+		*resources = append(*resources, string(sourceObjectJson))
+	}
 
-    return err
+	return err
 }
 
 // GetSourcesList return a JSON compatible list of objects with the target as first item, and the additionalSources after it
 func (r *WorkloadActionReconciler) GetSourcesList(ctx context.Context, workloadManifest *rabbitstalkerv1alpha1.WorkloadAction) (resources []string, err error) {
 
-    // Fill the resources list with the target
-    err = r.addWorkloadResource(ctx, workloadManifest, &resources)
-    if err != nil {
-        return resources, err
-    }
+	// Fill the resources list with the target
+	err = r.addWorkloadResource(ctx, workloadManifest, &resources)
+	if err != nil {
+		return resources, err
+	}
 
-    // Fill the resources list with the sources
-    err = r.addAdditionalSources(ctx, workloadManifest, &resources)
-    if err != nil {
-        return resources, err
-    }
+	// Fill the resources list with the sources
+	err = r.addAdditionalSources(ctx, workloadManifest, &resources)
+	if err != nil {
+		return resources, err
+	}
 
-    return resources, err
+	return resources, err
 }
 
 // GetParsedConditionValue return condition's value field with all substitutions already done
 func (r *WorkloadActionReconciler) GetParsedConditionValue(ctx context.Context, workloadManifest *rabbitstalkerv1alpha1.WorkloadAction) (conditionValue string, err error) {
-    referenceOpeningPattern := `\[\d+\]`
-    openingPattern := `{{`
-    closingPattern := `}}`
+	referenceOpeningPattern := `\[\d+\]`
+	openingPattern := `{{`
+	closingPattern := `}}`
 
-    var sourcesJson []string
-    sourcesJson, err = r.GetSourcesList(ctx, workloadManifest)
-    if err != nil {
-        return conditionValue, err
-    }
+	var sourcesJson []string
+	sourcesJson, err = r.GetSourcesList(ctx, workloadManifest)
+	if err != nil {
+		return conditionValue, err
+	}
 
-    // Ignore looping on empty sources
-    if len(sourcesJson) == 0 {
-        return conditionValue, err
-    }
+	// Ignore looping on empty sources
+	if len(sourcesJson) == 0 {
+		return conditionValue, err
+	}
 
-    regexPattern := fmt.Sprintf(`%s%s([\s\S]*?)%s`, referenceOpeningPattern, regexp.QuoteMeta(openingPattern), regexp.QuoteMeta(closingPattern))
-    regex := regexp.MustCompile(regexPattern)
+	regexPattern := fmt.Sprintf(`%s%s([\s\S]*?)%s`, referenceOpeningPattern, regexp.QuoteMeta(openingPattern), regexp.QuoteMeta(closingPattern))
+	regex := regexp.MustCompile(regexPattern)
 
-    // Look for potential replacements on condition.value
-    conditionValue = workloadManifest.Spec.Condition.Value
-    matches := regex.FindAllStringSubmatch(conditionValue, -1)
+	// Look for potential replacements on condition.value
+	conditionValue = workloadManifest.Spec.Condition.Value
+	matches := regex.FindAllStringSubmatch(conditionValue, -1)
 
-    for _, match := range matches {
-        // Look for the desired source in each replacement
-        srcIndexString := match[0][strings.IndexByte(match[0], '[')+1 : strings.IndexByte(match[0], ']')]
-        srcIndex, err := strconv.Atoi(srcIndexString)
-        if err != nil {
-            err = errors.New("invalid source index on condition value")
-            return conditionValue, err
-        }
+	for _, match := range matches {
+		// Look for the desired source in each replacement
+		srcIndexString := match[0][strings.IndexByte(match[0], '[')+1 : strings.IndexByte(match[0], ']')]
+		srcIndex, err := strconv.Atoi(srcIndexString)
+		if err != nil {
+			err = errors.New("invalid source index on condition value")
+			return conditionValue, err
+		}
 
-        // Check index is lower than sources length
-        if srcIndex >= len(sourcesJson) {
-            err = errors.New("invalid index to the sources list")
-            return conditionValue, err
-        }
+		// Check index is lower than sources length
+		if srcIndex >= len(sourcesJson) {
+			err = errors.New("invalid index to the sources list")
+			return conditionValue, err
+		}
 
-        match[1] = strings.TrimSpace(match[1])
+		match[1] = strings.TrimSpace(match[1])
 
-        parsedValue := gjson.Get(sourcesJson[srcIndex], match[1])
+		parsedValue := gjson.Get(sourcesJson[srcIndex], match[1])
 
-        conditionValue = strings.Replace(conditionValue, match[0], parsedValue.String(), 1)
-    }
+		conditionValue = strings.Replace(conditionValue, match[0], parsedValue.String(), 1)
+	}
 
-    return conditionValue, err
+	return conditionValue, err
 }
 
 // SetWorkloadRestartAnnotation restart a workload by changing an annotation.
 // This will trigger an automatic reconciliation on the workload in the same way done by kubectl
 func (r *WorkloadActionReconciler) SetWorkloadRestartAnnotation(ctx context.Context, obj *unstructured.Unstructured) (err error) {
 
-    var templateAnnotations map[string]interface{}
+	var templateAnnotations map[string]interface{}
 
-    resourceType := obj.GetObjectKind().GroupVersionKind()
-    // TODO: Check the group version just in case future changes on Kubernetes APIs
-    //groupVersion := resourceType.GroupVersion()
+	resourceType := obj.GetObjectKind().GroupVersionKind()
+	// TODO: Check the group version just in case future changes on Kubernetes APIs
+	//groupVersion := resourceType.GroupVersion()
 
-    // 1. Check allowed workload types
-    kind := resourceType.Kind
-    if kind != ResourceKindDeployment && kind != ResourceKindDaemonSet && kind != ResourceKindStatefulSet {
-        return fmt.Errorf(WorkloadRestartNotSupportedErrorMessage)
-    }
+	// 1. Check allowed workload types
+	kind := resourceType.Kind
+	if kind != ResourceKindDeployment && kind != ResourceKindDaemonSet && kind != ResourceKindStatefulSet {
+		return fmt.Errorf(WorkloadRestartNotSupportedErrorMessage)
+	}
 
-    // 2. Pay special attention on paused deployments
-    if kind == ResourceKindDeployment {
-        pausedValue, pausedFound, err := unstructured.NestedBool(obj.Object, "spec", "paused")
-        if err != nil {
-            return err
-        }
+	// 2. Pay special attention on paused deployments
+	if kind == ResourceKindDeployment {
+		pausedValue, pausedFound, err := unstructured.NestedBool(obj.Object, "spec", "paused")
+		if err != nil {
+			return err
+		}
 
-        if pausedFound && pausedValue == true {
-            err = errors.New(PausedWorkloadRestartErrorMessage)
-            return err
-        }
-    }
+		if pausedFound && pausedValue == true {
+			err = errors.New(PausedWorkloadRestartErrorMessage)
+			return err
+		}
+	}
 
-    // 3. Modify template annotations (spec.template.metadata.annotations) to include AnnotationRestartedAt
-    templateAnnotations, templateAnnotationsFound, err := unstructured.NestedMap(obj.Object, "spec", "template", "metadata", "annotations")
-    if err != nil {
-        return err
-    }
+	// 3. Modify template annotations (spec.template.metadata.annotations) to include AnnotationRestartedAt
+	templateAnnotations, templateAnnotationsFound, err := unstructured.NestedMap(obj.Object, "spec", "template", "metadata", "annotations")
+	if err != nil {
+		return err
+	}
 
-    // Take care about annotations not being present
-    if !templateAnnotationsFound || templateAnnotations == nil {
-        templateAnnotations = map[string]interface{}{}
-    }
-    templateAnnotations[AnnotationRestartedAt] = time.Now().Format(time.RFC3339)
+	// Take care about annotations not being present
+	if !templateAnnotationsFound || templateAnnotations == nil {
+		templateAnnotations = map[string]interface{}{}
+	}
+	templateAnnotations[AnnotationRestartedAt] = time.Now().Format(time.RFC3339)
 
-    // 4. Actually update the workload object against Kubernetes API
-    parsedTemplateAnnotations, err := json.Marshal(templateAnnotations)
-    if err != nil {
-        return err
-    }
+	// 4. Actually update the workload object against Kubernetes API
+	parsedTemplateAnnotations, err := json.Marshal(templateAnnotations)
+	if err != nil {
+		return err
+	}
 
-    patchBytes := []byte(fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":%s}}}}`, parsedTemplateAnnotations))
+	patchBytes := []byte(fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":%s}}}}`, parsedTemplateAnnotations))
 
-    err = r.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType, patchBytes))
-    if err != nil {
-        err = errors.New(fmt.Sprintf(WorkloadActionAnnotationPatchErrorMessage, err))
-    }
+	err = r.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType, patchBytes))
+	if err != nil {
+		err = errors.New(fmt.Sprintf(WorkloadActionAnnotationPatchErrorMessage, err))
+	}
 
-    return err
+	return err
 }
 
 // getHttpContent execute a request against a server and return the response in bytes
 func (r *WorkloadActionReconciler) getHttpContent(url string, auth HttpRequestAuth) (statusCode int, responseBytes []byte, err error) {
 
-    statusCode = http.StatusOK
+	httpClient := http.Client{Timeout: HttpRequestTimeoutDefaultValue}
 
-    httpClient := http.Client{Timeout: HttpRequestTimeout}
+	request, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return statusCode, responseBytes, err
+	}
 
-    request, err := http.NewRequest(http.MethodGet, url, http.NoBody)
-    if err != nil {
-        return statusCode, responseBytes, err
-    }
+	request.Header.Add("Accept", HttpHeaderAcceptDefaultValue)
 
-    request.Header.Add("Accept", HttpHeaderAccept)
+	if len(auth.Username) != 0 && len(auth.Password) != 0 {
+		request.SetBasicAuth(auth.Username, auth.Password)
+	}
 
-    if len(auth.Username) != 0 && len(auth.Password) != 0 {
-        request.SetBasicAuth(auth.Username, auth.Password)
-    }
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return statusCode, responseBytes, err
+	}
 
-    response, err := httpClient.Do(request)
-    if err != nil {
-        return response.StatusCode, responseBytes, err
-    }
+	defer response.Body.Close()
 
-    defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		err = errors.New(fmt.Sprintf(UnsuccessfulRequestErrorMessage, response.StatusCode))
+		return response.StatusCode, responseBytes, err
+	}
 
-    if response.StatusCode == http.StatusUnauthorized {
-        err = errors.New(UnauthorizedRequestErrorMessage)
-        return response.StatusCode, responseBytes, err
-    }
+	responseBytes, err = io.ReadAll(response.Body)
+	if err != nil {
+		return response.StatusCode, responseBytes, err
+	}
 
-    if response.StatusCode != http.StatusOK {
-        err = errors.New(fmt.Sprintf(UnsuccessfulRequestErrorMessage, response.StatusCode))
-        return response.StatusCode, responseBytes, err
-    }
-
-    responseBytes, err = io.ReadAll(response.Body)
-    if err != nil {
-        return response.StatusCode, responseBytes, err
-    }
-
-    return response.StatusCode, responseBytes, err
+	return http.StatusOK, responseBytes, err
 }
 
 // getQueueFromSimpleResponse return the status for a specific queue on a non-paginated request
 func (r *WorkloadActionReconciler) getQueueFromSimpleResponse(parsedUrl *url.URL, requestAuth HttpRequestAuth) (statusCode int, queuePool [][]byte, err error) {
 
-    var responseBody []byte
+	var responseBody []byte
 
-    // Get the content of one page
-    statusCode, responseBody, err = r.getHttpContent(parsedUrl.String(), requestAuth)
-    if err != nil {
-        return statusCode, queuePool, err
-    }
+	// Get the content of one page
+	statusCode, responseBody, err = r.getHttpContent(parsedUrl.String(), requestAuth)
+	if err != nil {
+		return statusCode, queuePool, err
+	}
 
-    // Add item to queuePool
-    queuePool = append(queuePool, responseBody)
+	// Add item to queuePool
+	queuePool = append(queuePool, responseBody)
 
-    return statusCode, queuePool, err
+	return statusCode, queuePool, err
 }
 
 // getQueuesFromPaginatedResponse return all the queues' status across paginated results, together
 func (r *WorkloadActionReconciler) getQueuesFromPaginatedResponse(parsedUrl *url.URL, requestAuth HttpRequestAuth) (statusCode int, queuePool [][]byte, err error) {
 
-    var responseBody []byte
-    CurrentPage := StartingPageDefaultValue
+	var responseBody []byte
+	CurrentPage := StartingPageDefaultValue
 
-    //
-    regexParsedUrlQuery := parsedUrl.Query()
-    regexParsedUrlQuery.Set("page", strconv.Itoa(StartingPageDefaultValue))
-    parsedUrl.RawQuery = regexParsedUrlQuery.Encode()
+	//
+	regexParsedUrlQuery := parsedUrl.Query()
+	regexParsedUrlQuery.Set("page", strconv.Itoa(StartingPageDefaultValue))
+	parsedUrl.RawQuery = regexParsedUrlQuery.Encode()
 
-    // Get the queues information from all the pages
-    for {
-        // Get the content of one page
-        statusCode, responseBody, err = r.getHttpContent(parsedUrl.String(), requestAuth)
-        if err != nil {
-            return statusCode, queuePool, err
-        }
+	// Get the queues information from all the pages
+	for {
+		// Get the content of one page
+		statusCode, responseBody, err = r.getHttpContent(parsedUrl.String(), requestAuth)
+		if err != nil {
+			return statusCode, queuePool, err
+		}
 
-        // Transform response into Go well-known struct
-        data := RabbitPaginatedResponse{}
-        err := json.Unmarshal(responseBody, &data)
-        if err != nil {
-            return statusCode, queuePool, err
-        }
+		// Transform response into Go well-known struct
+		data := RabbitPaginatedResponse{}
+		err := json.Unmarshal(responseBody, &data)
+		if err != nil {
+			return statusCode, queuePool, err
+		}
 
-        // No items, don't waste compute resources processing
-        if data.ItemCount == 0 {
-            break
-        }
+		// No items, don't waste compute resources processing
+		if data.ItemCount == 0 {
+			break
+		}
 
-        // Add page's items to queuePool
-        for _, item := range data.Items {
-            itemBytes, err := json.Marshal(item)
-            if err != nil {
-                // TODO: Should we completely return or just ignore current page?
-                return statusCode, queuePool, err
-            }
-            queuePool = append(queuePool, itemBytes)
-        }
+		// Add page's items to queuePool
+		for _, item := range data.Items {
+			itemBytes, err := json.Marshal(item)
+			if err != nil {
+				// TODO: Should we completely return or just ignore current page?
+				return statusCode, queuePool, err
+			}
+			queuePool = append(queuePool, itemBytes)
+		}
 
-        // Last page or no items. Exit
-        if CurrentPage >= data.PageCount || data.ItemCount == 0 {
-            break
-        }
+		// Last page or no items. Exit
+		if CurrentPage >= data.PageCount || data.ItemCount == 0 {
+			break
+		}
 
-        // Items pending. Request them
-        CurrentPage++
-        temporaryParsedUrl := parsedUrl.Query()
-        temporaryParsedUrl.Set("page", strconv.Itoa(CurrentPage))
-        parsedUrl.RawQuery = temporaryParsedUrl.Encode()
-    }
+		// Items pending. Request them
+		CurrentPage++
+		temporaryParsedUrl := parsedUrl.Query()
+		temporaryParsedUrl.Set("page", strconv.Itoa(CurrentPage))
+		parsedUrl.RawQuery = temporaryParsedUrl.Encode()
+	}
 
-    return statusCode, queuePool, err
+	return statusCode, queuePool, err
 }
 
 // reconcileWorkloadAction call Kubernetes API to actually workloadAction the resource
 func (r *WorkloadActionReconciler) reconcileWorkloadAction(ctx context.Context, workloadActionManifest *rabbitstalkerv1alpha1.WorkloadAction) (err error) {
 
-    // 1. Get the workload object
-    targetObject, err := r.GetWorkloadResource(ctx, workloadActionManifest)
-    if err != nil {
-        r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
-            metav1.ConditionFalse,
-            ConditionReasonWorkloadNotFound,
-            ConditionReasonWorkloadNotFoundMessage,
-        ))
-        return err
-    }
+	// 1. Get the workload object
+	targetObject, err := r.GetWorkloadResource(ctx, workloadActionManifest)
+	if err != nil {
+		r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+			metav1.ConditionFalse,
+			ConditionReasonWorkloadNotFound,
+			ConditionReasonWorkloadNotFoundMessage,
+		))
+		return err
+	}
 
-    // 2. Look for the Secret resources only when credentials refs are set in WorkloadAction
-    var credentialsObjects []*corev1.Secret
+	// 2. Look for the Secret resources only when credentials refs are set in WorkloadAction
+	var credentialsObjects []*corev1.Secret
 
-    if !reflect.ValueOf(workloadActionManifest.Spec.RabbitConnection.Credentials).IsZero() {
-        credentialsObjects, err = r.GetCredentialsResources(ctx, workloadActionManifest)
-        if err != nil {
-            r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
-                metav1.ConditionFalse,
-                ConditionReasonCredentialsNotFound,
-                ConditionReasonCredentialsNotFoundMessage,
-            ))
-            return err
-        }
-    }
+	if !reflect.ValueOf(workloadActionManifest.Spec.RabbitConnection.Credentials).IsZero() {
+		credentialsObjects, err = r.GetCredentialsResources(ctx, workloadActionManifest)
+		if err != nil {
+			r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+				metav1.ConditionFalse,
+				ConditionReasonCredentialsNotFound,
+				ConditionReasonCredentialsNotFoundMessage,
+			))
+			return err
+		}
+	}
 
-    // 3. Fill the credentials only when the Secret resources where extracted
-    var username, password []byte
-    var usernameFound, passwordFound bool
+	// 3. Fill the credentials only when the Secret resources where extracted
+	var username, password []byte
+	var usernameFound, passwordFound bool
 
-    if len(credentialsObjects) == 2 {
-        username, usernameFound = credentialsObjects[0].Data[workloadActionManifest.Spec.RabbitConnection.Credentials.Username.SecretRef.Key]
-        password, passwordFound = credentialsObjects[1].Data[workloadActionManifest.Spec.RabbitConnection.Credentials.Password.SecretRef.Key]
-        if !usernameFound || !passwordFound {
-            r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
-                metav1.ConditionFalse,
-                ConditionReasonCredentialsNotFound,
-                ConditionReasonCredentialsNotFoundMessage,
-            ))
-            return err
-        }
-    }
+	if len(credentialsObjects) == 2 {
+		username, usernameFound = credentialsObjects[0].Data[workloadActionManifest.Spec.RabbitConnection.Credentials.Username.SecretRef.Key]
+		password, passwordFound = credentialsObjects[1].Data[workloadActionManifest.Spec.RabbitConnection.Credentials.Password.SecretRef.Key]
+		if !usernameFound || !passwordFound {
+			r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+				metav1.ConditionFalse,
+				ConditionReasonCredentialsNotFound,
+				ConditionReasonCredentialsNotFoundMessage,
+			))
+			return err
+		}
+	}
 
-    requestAuth := HttpRequestAuth{
-        Username: string(username),
-        Password: string(password),
-    }
+	requestAuth := HttpRequestAuth{
+		Username: string(username),
+		Password: string(password),
+	}
 
-    // 4. Configure the URL and params for the HTTP request
-    // Set request URL depending on literal or regex
-    urlString := workloadActionManifest.Spec.RabbitConnection.Url
-    urlString += fmt.Sprintf(RabbitAdminApiQueuesEndpoint,
-        workloadActionManifest.Spec.RabbitConnection.Vhost)
+	// 4. Configure the URL and params for the HTTP request
 
-    if !workloadActionManifest.Spec.RabbitConnection.UseRegex {
-        urlString += "/" + workloadActionManifest.Spec.RabbitConnection.Queue
-    }
+	// Queues with literal name MUST be searched inside a vhost
+	// TODO: Improve the status condition
+	if !workloadActionManifest.Spec.RabbitConnection.UseRegex &&
+		workloadActionManifest.Spec.RabbitConnection.Vhost == "" {
+		err = errors.New(VhostNotDefinedErrorMessage)
+		r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+			metav1.ConditionFalse,
+			ConditionReasonRequiredFieldNotFound,
+			ConditionReasonRequiredFieldNotFoundMessage,
+		))
+		return err
+	}
 
-    parsedUrl, err := url.Parse(urlString)
-    if err != nil {
-        r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
-            metav1.ConditionFalse,
-            ConditionReasonUrlParsingFailed,
-            ConditionReasonUrlParsingFailedMessage,
-        ))
-        return err
-    }
+	// Set request URL depending on literal or regex
+	urlString := workloadActionManifest.Spec.RabbitConnection.Url
 
-    // Set initial query params for paginated requests when needed
-    if workloadActionManifest.Spec.RabbitConnection.UseRegex {
-        regexParsedUrlQuery := parsedUrl.Query()
-        regexParsedUrlQuery.Set("page", strconv.Itoa(StartingPageDefaultValue))
-        regexParsedUrlQuery.Set("page_size", strconv.Itoa(PageSizeDefaultValue))
-        regexParsedUrlQuery.Set("name", workloadActionManifest.Spec.RabbitConnection.Queue)
-        regexParsedUrlQuery.Set("use_regex", strconv.FormatBool(UseRegexDefaultValue))
-        parsedUrl.RawQuery = regexParsedUrlQuery.Encode()
-    }
+	parsedUrl, err := url.Parse(urlString)
+	if err != nil {
+		r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+			metav1.ConditionFalse,
+			ConditionReasonUrlParsingFailed,
+			ConditionReasonUrlParsingFailedMessage,
+		))
+		return err
+	}
 
-    // 5. Make the HTTP request to the RabbitMQ admin API
-    var statusCode int
-    var queuePool [][]byte
+	// Set HTTPS when no scheme defined (secure by default)
+	if parsedUrl.Scheme == "" {
+		parsedUrl.Scheme = HttpSchemeDefaultValue
+	}
 
-    statusCode, queuePool, err = r.getQueueFromSimpleResponse(parsedUrl, requestAuth)
-    if workloadActionManifest.Spec.RabbitConnection.UseRegex {
-        statusCode, queuePool, err = r.getQueuesFromPaginatedResponse(parsedUrl, requestAuth)
-    }
+	// Point to queues' monitoring endpoint
+	parsedUrl = parsedUrl.JoinPath(RabbitAdminApiQueuesEndpoint)
 
-    if err != nil {
-        r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
-            metav1.ConditionFalse,
-            ConditionReasonHttpResponseNotSuccessful,
-            fmt.Sprintf(ConditionReasonHttpResponseNotSuccessfulMessage, statusCode),
-        ))
-        return err
-    }
+	// Set the Vhost always when it's set on manifest
+	if workloadActionManifest.Spec.RabbitConnection.Vhost != "" {
+		parsedUrl = parsedUrl.JoinPath(workloadActionManifest.Spec.RabbitConnection.Vhost)
+	}
 
-    // 6. Evaluate the condition to execute an action.
-    // The condition.value is computed first as it's computed only once.
-    parsedValue, err := r.GetParsedConditionValue(ctx, workloadActionManifest)
-    if err != nil {
-        r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
-            metav1.ConditionFalse,
-            ConditionReasonConditionValueParsingFailed,
-            ConditionReasonConditionValueParsingFailedMessage,
-        ))
-        return err
-    }
+	// Set queue name on URL when using a literal queueName
+	if !workloadActionManifest.Spec.RabbitConnection.UseRegex {
+		parsedUrl = parsedUrl.JoinPath(workloadActionManifest.Spec.RabbitConnection.Queue)
+	}
 
-    // We allow regex for the queue.name. That means there could be different results on condition.key for each queue.
-    // because of that, we need to compare them all against condition.value, one by one
-    for queueItemIndex, queueItem := range queuePool {
+	// Set initial query params for paginated requests when needed
+	if workloadActionManifest.Spec.RabbitConnection.UseRegex {
+		regexParsedUrlQuery := parsedUrl.Query()
+		regexParsedUrlQuery.Set("page", strconv.Itoa(StartingPageDefaultValue))
+		regexParsedUrlQuery.Set("page_size", strconv.Itoa(PageSizeDefaultValue))
+		regexParsedUrlQuery.Set("name", workloadActionManifest.Spec.RabbitConnection.Queue)
+		regexParsedUrlQuery.Set("use_regex", strconv.FormatBool(UseRegexDefaultValue))
+		parsedUrl.RawQuery = regexParsedUrlQuery.Encode()
+	}
 
-        // Ref: https://gjson.dev/
-        if !gjson.Valid(string(queueItem)) {
-            err = errors.New(InvalidJsonErrorMessage)
-            r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
-                metav1.ConditionFalse,
-                ConditionReasonHttpResponseNotValid,
-                ConditionReasonHttpResponseNotValidMessage,
-            ))
-            return err
-        }
+	// TODO DEBUG HERE ONLY
+	log.Printf("parsedURL 4: %v", parsedUrl.String())
 
-        // Parse the condition for current item
-        // Condition is met for some item? go to action's execution
-        parsedKey := gjson.GetBytes(queueItem, workloadActionManifest.Spec.Condition.Key)
-        if parsedKey.String() == parsedValue {
-            break
-        }
+	// 5. Make the HTTP request to the RabbitMQ admin API
+	var statusCode int
+	var queuePool [][]byte
 
-        // Last loop. Condition was not met. Return without execution
-        if len(queuePool) == queueItemIndex+1 {
-            return err
-        }
-    }
+	switch workloadActionManifest.Spec.RabbitConnection.UseRegex {
+	case true:
+		statusCode, queuePool, err = r.getQueuesFromPaginatedResponse(parsedUrl, requestAuth)
+	default:
+		statusCode, queuePool, err = r.getQueueFromSimpleResponse(parsedUrl, requestAuth)
+	}
 
-    // 7. Condition is met. Execute the action
-    switch workloadActionManifest.Spec.Action {
-    case ActionRestart:
-        err = r.SetWorkloadRestartAnnotation(ctx, targetObject)
-    case ActionDelete:
-        err = errors.New(DeleteActionNotImplementedErrorMessage)
-    default:
-        err = errors.New(InvalidActionErrorMessage)
-        r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
-            metav1.ConditionFalse,
-            ConditionReasonInvalidAction,
-            ConditionReasonInvalidActionMessage,
-        ))
-        return err
-    }
+	if err != nil {
+		r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+			metav1.ConditionFalse,
+			ConditionReasonHttpResponseNotSuccessful,
+			fmt.Sprintf(ConditionReasonHttpResponseNotSuccessfulMessage, statusCode),
+		))
+		return err
+	}
 
-    if err != nil {
-        r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
-            metav1.ConditionFalse,
-            ConditionReasonActionExecutionFailed,
-            ConditionReasonActionExecutionFailedMessage,
-        ))
-    }
+	// Check whether some queue was found or not
+	if len(queuePool) == 0 {
+		err = errors.New(QueuesNotFoundErrorMessage)
+		r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+			metav1.ConditionFalse,
+			ConditionReasonQueueNotFound,
+			ConditionReasonQueueNotFoundMessage,
+		))
+		return err
+	}
 
-    return err
+	// 6. Evaluate the condition to execute an action.
+	// The condition.value is computed first as it's computed only once.
+	parsedValue, err := r.GetParsedConditionValue(ctx, workloadActionManifest)
+	if err != nil {
+		r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+			metav1.ConditionFalse,
+			ConditionReasonConditionValueParsingFailed,
+			ConditionReasonConditionValueParsingFailedMessage,
+		))
+		return err
+	}
+
+	// We allow regex for the queue.name. That means there could be different results on condition.key for each queue.
+	// because of that, we need to compare them all against condition.value, one by one
+	for queueItemIndex, queueItem := range queuePool {
+
+		// Ref: https://gjson.dev/
+		if !gjson.Valid(string(queueItem)) {
+			err = errors.New(InvalidJsonErrorMessage)
+			r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+				metav1.ConditionFalse,
+				ConditionReasonHttpResponseNotValid,
+				ConditionReasonHttpResponseNotValidMessage,
+			))
+			return err
+		}
+
+		// Parse the condition for current item
+		// Condition is met for some item? go to action's execution
+		parsedKey := gjson.GetBytes(queueItem, workloadActionManifest.Spec.Condition.Key)
+		if parsedKey.String() == parsedValue {
+			break
+		}
+
+		// Last loop. Condition was not met. Return without execution
+		if len(queuePool) == queueItemIndex+1 {
+			return err
+		}
+	}
+
+	// 7. Condition is met. Execute the action
+	switch workloadActionManifest.Spec.Action {
+	case ActionRestart:
+		err = r.SetWorkloadRestartAnnotation(ctx, targetObject)
+	case ActionDelete:
+		err = errors.New(DeleteActionNotImplementedErrorMessage)
+	default:
+		err = errors.New(InvalidActionErrorMessage)
+		r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+			metav1.ConditionFalse,
+			ConditionReasonInvalidAction,
+			ConditionReasonInvalidActionMessage,
+		))
+		return err
+	}
+
+	if err != nil {
+		r.UpdateWorkloadActionCondition(workloadActionManifest, r.NewWorkloadActionCondition(ConditionTypeWorkloadActionReady,
+			metav1.ConditionFalse,
+			ConditionReasonActionExecutionFailed,
+			ConditionReasonActionExecutionFailedMessage,
+		))
+	}
+
+	return err
 }


### PR DESCRIPTION
**Description:**

* `spec.rabbitConnection.vhost` is now optional on regex-based searches for queue name

* Now it's possible to use credentials located in different namespaces. When a namespace is not defined on credentials' Secret reference, the controller will use the same namespace where the WorkloadAction CR's is located. For that, two new fields were added:
  * `spec.rabbitConnection.credentials.username.secretRef.namespace`
  * `spec.rabbitConnection.credentials.password.secretRef.namespace`

* New predicate added to the controller to avoid enqueue WorkloadAction events when they are only triggered by status updates. [More info here](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/predicate#GenerationChangedPredicate)

* Improve some `status.conditions` and the checks done before throwing them. Done to give better information to the user and fix some situations where the controller broke unexpetedly
  * The controller does not explode on unknown URL schemes anymore
  * Default scheme is set to `https` when not defined in the URL
  * Some StatusConditions where introduced
    * _NoQueueFound_
    * _ConditionReasonRequiredFieldNotFound_

* Improve documentation on `README`